### PR TITLE
Fix PLDoc Generation

### DIFF
--- a/scripts/rosprolog-doc
+++ b/scripts/rosprolog-doc
@@ -13,4 +13,4 @@ if [ -n "$1" ] && [ -n "$(rospack find $1)" ]; then
 fi
 
 cd "$(rospack find $1)"
-exec /usr/bin/swipl -q -f ${PLDOC_INIT_FILE}  ${SCRIPT_FILE} ${PL_ARGS}
+exec /usr/bin/swipl -q -f ${PLDOC_INIT_FILE} ${SCRIPT_FILE}


### PR DESCRIPTION
PLDoc does not work under noetic. It throws the error:

```
ERROR: Prolog initialisation failed:
ERROR: file `knowrob' does not exist
```

This PR fixes the error and the doc generation works again.